### PR TITLE
Add 4s fade effect when removing tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
       border-bottom: 1px solid #eee;
       flex-wrap: wrap;
       gap: 5px;
-      transition: opacity 5s ease;
+      transition: opacity 4s ease;
       opacity: 1;
     }
     .task-item.fade-out {
@@ -1427,7 +1427,12 @@ function toggleTask(taskId, dateKey) {
       (task.repeat === 'daily' && task.completions[dateKey])) {
     const li = document.querySelector(`.task-item[data-task-id="${taskId}"]`);
     li.classList.add('fade-out');
-    setTimeout(() => li.remove(), 500);  // remove after 0.5s
+    setTimeout(() => {
+      li.remove();
+      saveUserData();
+      renderTasks();
+    }, 4000);  // remove after fade-out
+    return;
   }
 
   saveUserData();
@@ -1435,9 +1440,20 @@ function toggleTask(taskId, dateKey) {
 }
 
   function deleteTask(taskId) {
-    taskLists[currentTaskList] = taskLists[currentTaskList].filter(t => t.id != taskId);
-    saveUserData();
-    renderTasks();
+    const li = document.querySelector(`.task-item[data-task-id="${taskId}"]`);
+    if (li) {
+      li.classList.add('fade-out');
+      setTimeout(() => {
+        li.remove();
+        taskLists[currentTaskList] = taskLists[currentTaskList].filter(t => t.id != taskId);
+        saveUserData();
+        renderTasks();
+      }, 4000);
+    } else {
+      taskLists[currentTaskList] = taskLists[currentTaskList].filter(t => t.id != taskId);
+      saveUserData();
+      renderTasks();
+    }
   }
 
   // Replace the initializeTaskControls function with this improved version


### PR DESCRIPTION
## Summary
- shorten the task fade-out transition to 4s
- delay DOM removal so tasks fade out over 4 seconds when marked complete or deleted

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6849ec1d60108328996389bcf8f11bd7