### PR TITLE
Implement desktop time picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,14 @@
       margin-bottom: 5px;
       font-size: 14px;
     }
+    .time-select {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+    }
+    .time-select select {
+      padding: 6px;
+    }
     .event-actions {
       display: flex;
       flex-wrap: wrap;
@@ -483,12 +491,18 @@
   <input type="text" id="eventDescription" placeholder="Event Name" required>
   <div class="time-inputs">
     <div>
-      <label for="eventStartTime">Start Time:</label>
-      <input type="time" id="eventStartTime" required>
+      <label for="eventStartHour">Start Time:</label>
+      <div class="time-select">
+        <select id="eventStartHour"></select> :
+        <select id="eventStartMinute"></select>
+      </div>
     </div>
     <div>
-      <label for="eventEndTime">End Time:</label>
-      <input type="time" id="eventEndTime" required>
+      <label for="eventEndHour">End Time:</label>
+      <div class="time-select">
+        <select id="eventEndHour"></select> :
+        <select id="eventEndMinute"></select>
+      </div>
     </div>
   </div>
   <h4>Select Color:</h4>
@@ -844,6 +858,41 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
   return `${h}:${m} ${ampm}`;
 }
 
+function padTime(n) {
+  return n.toString().padStart(2, '0');
+}
+
+function populateTimeSelectors() {
+  const hourSelects = [
+    document.getElementById('eventStartHour'),
+    document.getElementById('eventEndHour')
+  ];
+  const minuteSelects = [
+    document.getElementById('eventStartMinute'),
+    document.getElementById('eventEndMinute')
+  ];
+
+  hourSelects.forEach(select => {
+    select.innerHTML = '';
+    for (let h = 0; h < 24; h++) {
+      const opt = document.createElement('option');
+      opt.value = padTime(h);
+      opt.textContent = padTime(h);
+      select.appendChild(opt);
+    }
+  });
+
+  minuteSelects.forEach(select => {
+    select.innerHTML = '';
+    for (let m = 0; m < 60; m++) {
+      const opt = document.createElement('option');
+      opt.value = padTime(m);
+      opt.textContent = padTime(m);
+      select.appendChild(opt);
+    }
+  });
+}
+
 
 function initializeColorPicker(preSelected = selectedColor) {
   const colorPicker = document.getElementById("colorPicker");
@@ -1111,8 +1160,11 @@ function initializeColorPicker(preSelected = selectedColor) {
     document.getElementById('eventDate').value = date;
     document.getElementById('eventId').value = '';
     document.getElementById('eventDescription').value = '';
-    document.getElementById('eventStartTime').value = '';
-    document.getElementById('eventEndTime').value = '';
+    populateTimeSelectors();
+    document.getElementById('eventStartHour').selectedIndex = 0;
+    document.getElementById('eventStartMinute').selectedIndex = 0;
+    document.getElementById('eventEndHour').selectedIndex = 0;
+    document.getElementById('eventEndMinute').selectedIndex = 0;
     eventForm.style.display = 'block';
     initializeColorPicker();
     document.querySelector('.delete-event-btn').style.display = 'none';
@@ -1122,8 +1174,13 @@ function initializeColorPicker(preSelected = selectedColor) {
   function editEvent(event, index) {
     const eventForm = document.getElementById('eventForm');
     document.getElementById('eventDate').value = event.date;
-    document.getElementById('eventStartTime').value = event.startTime;
-    document.getElementById('eventEndTime').value = event.endTime;
+    populateTimeSelectors();
+    const [sh, sm] = event.startTime.split(':');
+    const [eh, em] = event.endTime.split(':');
+    document.getElementById('eventStartHour').value = sh;
+    document.getElementById('eventStartMinute').value = sm;
+    document.getElementById('eventEndHour').value = eh;
+    document.getElementById('eventEndMinute').value = em;
     document.getElementById('eventDescription').value = event.description;
     document.getElementById('eventId').value = index;
     selectedColor = event.color;
@@ -1149,8 +1206,10 @@ function initializeColorPicker(preSelected = selectedColor) {
 
   function saveEvent() {
     const date = document.getElementById('eventDate').value;
-    const startTime = document.getElementById('eventStartTime').value;
-    const endTime = document.getElementById('eventEndTime').value;
+    const startTime = padTime(document.getElementById('eventStartHour').value) + ':' +
+                      padTime(document.getElementById('eventStartMinute').value);
+    const endTime = padTime(document.getElementById('eventEndHour').value) + ':' +
+                    padTime(document.getElementById('eventEndMinute').value);
     const description = document.getElementById('eventDescription').value;
     const eventId = document.getElementById('eventId').value;
 


### PR DESCRIPTION
## Summary
- switch event times to scroll-style selects instead of text
- add helper to populate time selects
- save selected times when adding or editing events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6849f0e0ffe88328a3e3fc1734f45644