### PR TITLE
Improve desktop time input

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,16 @@
       margin-bottom: 5px;
       font-size: 14px;
     }
+    .time-picker {
+      display: flex;
+      align-items: center;
+      margin-bottom: 10px;
+    }
+    /* custom time picker dropdowns for desktop */
+    .time-picker select {
+      padding: 8px;
+      margin-right: 4px;
+    }
     .event-actions {
       display: flex;
       flex-wrap: wrap;
@@ -769,6 +779,61 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
   let mediaRecorder = null;
   let recordedChunks = [];
 
+  // ─── Simple desktop time picker using dropdowns ───
+  function isMobileDevice() {
+    return /Mobi|Android/i.test(navigator.userAgent);
+  }
+
+  function createTimePicker(inputId) {
+    const input = document.getElementById(inputId);
+    if (!input || isMobileDevice()) return;
+
+    const container = document.createElement('div');
+    container.className = 'time-picker';
+    const hours = document.createElement('select');
+    const minutes = document.createElement('select');
+
+    for (let h = 0; h < 24; h++) {
+      const opt = document.createElement('option');
+      opt.value = opt.textContent = String(h).padStart(2, '0');
+      hours.appendChild(opt);
+    }
+    for (let m = 0; m < 60; m++) {
+      const opt = document.createElement('option');
+      opt.value = opt.textContent = String(m).padStart(2, '0');
+      minutes.appendChild(opt);
+    }
+
+    container.appendChild(hours);
+    container.appendChild(document.createTextNode(' : '));
+    container.appendChild(minutes);
+
+    function syncFromInput() {
+      if (input.value) {
+        const [h, m] = input.value.split(':');
+        hours.value = h;
+        minutes.value = m;
+      } else {
+        hours.value = '00';
+        minutes.value = '00';
+      }
+    }
+
+    function syncToInput() {
+      input.value = hours.value + ':' + minutes.value;
+    }
+
+    hours.onchange = syncToInput;
+    minutes.onchange = syncToInput;
+
+    syncFromInput();
+
+    input.style.display = 'none';
+    input.parentNode.insertBefore(container, input.nextSibling);
+
+    input.setTimePicker = { syncFromInput };
+  }
+
   // journal navigation mode
   let journalMode = false;
   let journalEntryDates = [];
@@ -1113,6 +1178,8 @@ function initializeColorPicker(preSelected = selectedColor) {
     document.getElementById('eventDescription').value = '';
     document.getElementById('eventStartTime').value = '';
     document.getElementById('eventEndTime').value = '';
+    document.getElementById('eventStartTime').setTimePicker?.syncFromInput();
+    document.getElementById('eventEndTime').setTimePicker?.syncFromInput();
     eventForm.style.display = 'block';
     initializeColorPicker();
     document.querySelector('.delete-event-btn').style.display = 'none';
@@ -1124,6 +1191,8 @@ function initializeColorPicker(preSelected = selectedColor) {
     document.getElementById('eventDate').value = event.date;
     document.getElementById('eventStartTime').value = event.startTime;
     document.getElementById('eventEndTime').value = event.endTime;
+    document.getElementById('eventStartTime').setTimePicker?.syncFromInput();
+    document.getElementById('eventEndTime').setTimePicker?.syncFromInput();
     document.getElementById('eventDescription').value = event.description;
     document.getElementById('eventId').value = index;
     selectedColor = event.color;
@@ -1652,6 +1721,8 @@ Object.assign(window, {
   confirmAddHabit, cancelAddHabit, saveHabitTracker, cancelHabitTracker
 });
 generateCalendar();   // render current month on first load
+createTimePicker('eventStartTime');
+createTimePicker('eventEndTime');
 
 // Add an event listener to the button directly
 document.getElementById('logoutButton').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add a custom dropdown-based time picker for desktop users
- sync the new picker when adding or editing an event
- initialize the picker after the calendar renders

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684a00788c5c8328922deddb1c54c076