### PR TITLE
Add scroll-box time picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,7 @@
     .time-inputs div {
       flex: 1;
       min-width: 120px;
+      position: relative; /* for absolute dropdown positioning */
     }
     .time-inputs label {
       display: block;
@@ -133,14 +134,22 @@
       font-size: 14px;
     }
     .time-picker {
-      display: flex;
-      align-items: center;
-      margin-bottom: 10px;
+      position: absolute;
+      top: calc(100% + 4px);
+      left: 0;
+      background: white;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+      padding: 5px;
+      display: none;
+      z-index: 1001;
     }
-    /* custom time picker dropdowns for desktop */
     .time-picker select {
-      padding: 8px;
+      padding: 4px;
       margin-right: 4px;
+      height: 100px; /* show several options at once */
+      overflow-y: auto;
     }
     .time-picker select:last-child {
       margin-right: 0;
@@ -797,6 +806,10 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
     const minutes = document.createElement('select');
     const ampm = document.createElement('select');
 
+    hours.size = 5;
+    minutes.size = 5;
+    ampm.size = 2;
+
     for (let h = 1; h <= 12; h++) {
       const opt = document.createElement('option');
       opt.value = String(h).padStart(2, '0');
@@ -817,7 +830,6 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
     });
 
     container.appendChild(hours);
-    container.appendChild(document.createTextNode(' : '));
     container.appendChild(minutes);
     container.appendChild(ampm);
 
@@ -850,8 +862,24 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
 
     syncFromInput();
 
-    input.style.display = 'none';
-    input.parentNode.insertBefore(container, input.nextSibling);
+    input.parentNode.appendChild(container);
+
+    input.onclick = (e) => {
+      e.stopPropagation();
+      syncFromInput();
+      container.style.display = container.style.display === 'flex' ? 'none' : 'flex';
+    };
+
+    document.addEventListener('click', (evt) => {
+      if (!container.contains(evt.target) && evt.target !== input) {
+        container.style.display = 'none';
+      }
+    });
+
+    container.onchange = () => {
+      syncToInput();
+      container.style.display = 'none';
+    };
 
     input.setTimePicker = { syncFromInput };
   }


### PR DESCRIPTION
## Summary
- update time picker styles to show selectable lists in scroll boxes
- overhaul `createTimePicker` to display a pop-up selector for hours, minutes and AM/PM

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684a1729650c83288174218553fe8f4a