### PR TITLE
Remove scroll box from time picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,8 +148,6 @@
     .time-picker select {
       padding: 4px;
       margin-right: 4px;
-      height: 100px; /* show several options at once */
-      overflow-y: auto;
     }
     .time-picker select:last-child {
       margin-right: 0;
@@ -805,10 +803,6 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
     const hours = document.createElement('select');
     const minutes = document.createElement('select');
     const ampm = document.createElement('select');
-
-    hours.size = 5;
-    minutes.size = 5;
-    ampm.size = 2;
 
     for (let h = 1; h <= 12; h++) {
       const opt = document.createElement('option');


### PR DESCRIPTION
## Summary
- simplify time picker selects
- remove size attributes in `createTimePicker`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684a185c9d008328b3a12f2549befe39