### PR TITLE
Fix duplicate messaging variable in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -882,7 +882,6 @@ import { isSupported as messagingIsSupported } from
 
 
 /* 2️⃣ Register the service-worker & init Messaging (once) */
-let messaging;
 if (fcmSupported()) {
   messaging = getMessaging(app);
 


### PR DESCRIPTION
## Summary
- remove the second `let messaging` declaration in the module script

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_b_684f34b5da3c83289d81e53aed20cd0a