### PR TITLE
Add FCM registration snippet

### DIFF
--- a/index.html
+++ b/index.html
@@ -916,6 +916,31 @@ async function initFCM() {
 
 initFCM();
 
+// 1A) Register your SW & ask for notification permission
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .register('/firebase-messaging-sw.js', { scope: '/' })
+    .then(() => console.log('SW registered'))
+    .catch(console.error);
+
+  Notification.requestPermission()
+    .then(p => console.log('Notification permission', p));
+}
+
+// 1B) Capture & store the FCM token
+import { getMessaging, getToken } from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-messaging.js';
+const messaging = getMessaging(app);
+
+navigator.serviceWorker.ready.then(async reg => {
+  const fcmToken = await getToken(messaging, {
+    vapidKey: 'YOUR_VAPID_KEY',
+    serviceWorkerRegistration: reg
+  });
+  console.log('FCM token:', fcmToken);
+  // now save it in Firestore under the current user:
+  await setDoc(doc(db, 'users', userId), { fcmToken }, { merge: true });
+});
+
 
 
 


### PR DESCRIPTION
## Summary
- add service worker registration and FCM token storage after calling `initFCM()`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684f41b817b483288decc04f3a1d03dc