### PR TITLE
Fix Safari notification permission handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -923,8 +923,7 @@ if ('serviceWorker' in navigator) {
     .then(() => console.log('SW registered'))
     .catch(console.error);
 
-  Notification.requestPermission()
-    .then(p => console.log('Notification permission', p));
+  // Request permission when the user explicitly subscribes to notifications.
 }
 
 // 1B) Capture & store the FCM token


### PR DESCRIPTION
## Summary
- avoid calling `Notification.requestPermission()` on page load

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684f4f796f84832880f1c0f16ef973a4