### PR TITLE
Update Firebase CDN imports

### DIFF
--- a/firebase-messaging-sw.js
+++ b/firebase-messaging-sw.js
@@ -1,6 +1,6 @@
 importScripts(
-  'https://www.gstatic.com/firebasejs/11.6.0/firebase-app-compat.js',
-  'https://www.gstatic.com/firebasejs/11.6.0/firebase-messaging-compat.js'
+  'https://www.gstatic.com/firebasejs/11.10.0/firebase-app-compat.js',
+  'https://www.gstatic.com/firebasejs/11.10.0/firebase-messaging-compat.js'
 );
 
 // --- Firebase project config (same values you use in index.html) ---

--- a/index.html
+++ b/index.html
@@ -757,17 +757,17 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
   /********************** 
     1) Firebase Imports
   ***********************/
-  import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-app.js";
-  import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-analytics.js";
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/11.10.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/11.10.0/firebase-analytics.js";
   import {
     getAuth,
     GoogleAuthProvider,
     signInWithPopup,
     onAuthStateChanged,
     signOut
-  } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-auth.js";
-  import { getFirestore, doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-firestore.js";
-  import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.6.0/firebase-storage.js";
+  } from "https://www.gstatic.com/firebasejs/11.10.0/firebase-auth.js";
+  import { getFirestore, doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/11.10.0/firebase-firestore.js";
+  import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/11.10.0/firebase-storage.js";
   // NEW: push-subscription flow -------------------------------
 
   /********************** 
@@ -864,7 +864,7 @@ import {
   getMessaging,
   getToken,
   onMessage
-} from 'https://www.gstatic.com/firebasejs/11.6.0/firebase-messaging.js';
+} from 'https://www.gstatic.com/firebasejs/11.10.0/firebase-messaging.js';
 
 async function fcmSupported() {
   try {


### PR DESCRIPTION
## Summary
- bump Firebase CDN modules from v11.6.0 to v11.10.0

## Testing
- `grep -r "firebasejs" -n`


------
https://chatgpt.com/codex/tasks/task_b_684f4fb358988328bfe50074ce34708a