### PR TITLE
Remove duplicate service worker registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -916,30 +916,6 @@ async function initFCM() {
 
 initFCM();
 
-// 1A) Register your SW & ask for notification permission
-if ('serviceWorker' in navigator) {
-  navigator.serviceWorker
-    .register('/firebase-messaging-sw.js', { scope: '/' })
-    .then(() => console.log('SW registered'))
-    .catch(console.error);
-
-  Notification.requestPermission()
-    .then(p => console.log('Notification permission', p));
-}
-
-// 1B) Capture & store the FCM token
-const messaging = getMessaging(app);
-
-navigator.serviceWorker.ready.then(async reg => {
-  const fcmToken = await getToken(messaging, {
-    vapidKey: 'YOUR_VAPID_KEY',
-    serviceWorkerRegistration: reg
-  });
-  console.log('FCM token:', fcmToken);
-  // now save it in Firestore under the current user:
-  await setDoc(doc(db, 'users', userId), { fcmToken }, { merge: true });
-});
-
 
 
 


### PR DESCRIPTION
## Summary
- clean up FCM initialization by dropping the second service worker registration

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684f4fcfe2d88328966bf2a15aef9e8e