### PR TITLE
Fix FCM token logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -822,18 +822,6 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
       // Generate calendar, tasks, etc.
       generateCalendar();
       renderTasks();
-      try {
-        const registration = await navigator.serviceWorker.ready;
-        const messaging = getMessaging(app);
-        const fcmToken = await getToken(messaging, {
-          vapidKey: 'YOUR_VAPID_KEY',
-          serviceWorkerRegistration: registration
-        });
-        console.log('FCM token:', fcmToken);
-        await setDoc(doc(db, 'users', userId), { fcmToken }, { merge: true });
-      } catch (err) {
-        console.error('Error saving FCM token:', err);
-      }
     } else {
       // Show sign in button, hide logout button
       document.getElementById('authSection').style.display = 'block';


### PR DESCRIPTION
## Summary
- remove unconditional call to `getToken()` in auth state handler so that FCM token is only acquired when the **Enable Notifications** button is clicked

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_b_684f530814388328b8083239c2837c6f