### PR TITLE
Save FCM token after enabling notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -915,7 +915,8 @@ async function initFCM() {
         serviceWorkerRegistration: registration
       });
       console.log('✅ FCM token acquired:', fcmToken);
-      // TODO: save `fcmToken` to Firestore or your backend
+      const uid = auth.currentUser?.uid;
+      if (uid) await setDoc(doc(db, 'users', uid), { fcmToken }, { merge: true });
       alert('🎉 Notifications enabled!');
       subBtn.disabled = true;
       subBtn.textContent = 'Notifications On';


### PR DESCRIPTION
## Summary
- persist the FCM token in Firestore when user enables notifications

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684f53238c888328abf8e6e8c7157daf