### PR TITLE
Add FCM notification helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # mywebsite
+
+This project uses Firebase Cloud Messaging (FCM) for push notifications. To ensure background notifications are handled correctly, send **data-only** messages to the FCM API. Avoid a top-level `notification` block in the payload so that your `onBackgroundMessage` handler in `firebase-messaging-sw.js` runs.
+
+Example `curl` request:
+
+```bash
+curl -X POST https://fcm.googleapis.com/fcm/send \
+  -H "Authorization: key=YOUR_SERVER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "YOUR_FCM_TOKEN",
+    "priority": "high",
+    "data": {
+      "title": "Background Alert",
+      "body": "This came through the service worker 🎉"
+    }
+  }'
+```
+
+Ensure `firebase-messaging-sw.js` is served from the site root so it is reachable at:
+
+```
+https://ksteele98.github.io/mywebsite/firebase-messaging-sw.js
+```
+
+When the app receives a push while closed, this service worker's `onBackgroundMessage` callback displays the notification.
+
+## Send a test push from Node
+
+Use the provided `send-notification.js` script to deliver a data-only message. Set your FCM server key and target token as environment variables:
+
+```bash
+FCM_SERVER_KEY=YOUR_SERVER_KEY \
+FCM_TOKEN=YOUR_FCM_TOKEN \
+node send-notification.js
+```
+
+The script posts the payload shown above to the FCM endpoint so you can verify that background notifications work end-to-end.

--- a/firebase-messaging-sw.js
+++ b/firebase-messaging-sw.js
@@ -19,5 +19,13 @@ const messaging = firebase.messaging();
 messaging.onBackgroundMessage(({ notification, data }) => {
   const title = notification?.title ?? data?.title ?? 'Notification';
   const body  = notification?.body  ?? data?.body  ?? '';
-  self.registration.showNotification(title, { body });
+  self.registration.showNotification(title, {
+    body,
+    icon: '/icon-192.png'
+  });
+});
+
+self.addEventListener('notificationclick', evt => {
+  evt.notification.close();
+  evt.waitUntil(clients.openWindow('/'));
 });

--- a/send-notification.js
+++ b/send-notification.js
@@ -1,0 +1,38 @@
+const https = require('https');
+
+const serverKey = process.env.FCM_SERVER_KEY;
+const fcmToken  = process.env.FCM_TOKEN;
+
+if (!serverKey || !fcmToken) {
+  console.error('Usage: FCM_SERVER_KEY=... FCM_TOKEN=... node send-notification.js');
+  process.exit(1);
+}
+
+const payload = JSON.stringify({
+  to: fcmToken,
+  priority: 'high',
+  data: {
+    title: 'Background Alert',
+    body:  'This came through the service worker \uD83C\uDF89'
+  }
+});
+
+const options = {
+  hostname: 'fcm.googleapis.com',
+  path: '/fcm/send',
+  method: 'POST',
+  headers: {
+    'Authorization': `key=${serverKey}`,
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(payload)
+  }
+};
+
+const req = https.request(options, res => {
+  console.log('Status:', res.statusCode);
+  res.on('data', d => process.stdout.write(d));
+});
+
+req.on('error', err => console.error('Request error:', err));
+req.write(payload);
+req.end();


### PR DESCRIPTION
## Summary
- handle notification clicks in `firebase-messaging-sw.js`
- show an icon when displaying background notifications
- add `send-notification.js` script for testing FCM pushes
- document how to use the script

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684f78995e888328bcfdc17382504133