### PR TITLE
Use data-only FCM payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 # mywebsite
 
-This project uses Firebase Cloud Messaging (FCM) for push notifications. To ensure background notifications are handled correctly, send **data-only** messages to the FCM API. Avoid a top-level `notification` block in the payload so that your `onBackgroundMessage` handler in `firebase-messaging-sw.js` runs.
+This project uses Firebase Cloud Messaging (FCM) for push notifications. Use **data-only** payloads so that your service worker's `onBackgroundMessage` handler runs. Avoid including a top-level `notification` object.
 
 Example `curl` request:
 
 ```bash
-curl -X POST https://fcm.googleapis.com/fcm/send \
-  -H "Authorization: key=YOUR_SERVER_KEY" \
+curl -X POST https://fcm.googleapis.com/v1/projects/YOUR_PROJECT_ID/messages:send \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "to": "YOUR_FCM_TOKEN",
-    "priority": "high",
-    "data": {
-      "title": "Background Alert",
-      "body": "This came through the service worker 🎉"
+    "message": {
+      "token": "YOUR_FCM_TOKEN",
+      "data": {
+        "title": "Background Alert",
+        "body": "This came through the service worker 🎉"
+      }
     }
   }'
 ```

--- a/firebase-messaging-sw.js
+++ b/firebase-messaging-sw.js
@@ -16,8 +16,8 @@ firebase.initializeApp({
 const messaging = firebase.messaging();
 
 // Handle background messages
-messaging.onBackgroundMessage(({ notification, data }) => {
-  const title = notification?.title ?? data?.title ?? 'Notification';
-  const body  = notification?.body  ?? data?.body  ?? '';
+messaging.onBackgroundMessage(({ data }) => {
+  const title = data?.title ?? 'Notification';
+  const body  = data?.body  ?? '';
   self.registration.showNotification(title, { body });
 });

--- a/index.html
+++ b/index.html
@@ -908,9 +908,12 @@ async function initFCM() {
   });
 
   const messaging = getMessaging(app);
-  onMessage(messaging, ({ notification }) =>
-    new Notification(notification.title, { body: notification.body })
-  );
+  // Foreground messages use a data-only payload so we manually
+  // display the toast using the `data` object.
+  onMessage(messaging, ({ data }) => {
+    if (!data) return;
+    new Notification(data.title, { body: data.body });
+  });
 }
 
 initFCM();


### PR DESCRIPTION
## Summary
- tweak README with FCM v1 data-only example
- display push data in the main page
- only handle data payloads in `firebase-messaging-sw.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6850f5d19f9083288a64e126262b872f