### PR TITLE
Enable habit navigation via journal arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -1304,6 +1304,10 @@ function initializeColorPicker(preSelected = selectedColor) {
       if (journalEntryIndex >= journalEntryDates.length) journalEntryIndex = journalEntryDates.length - 1;
       const newDateStr = journalEntryDates[journalEntryIndex];
       openJournal(newDateStr);
+      const habitForm = document.getElementById('habitForm');
+      if (habitForm.style.display !== 'none') {
+        _changeToHabit();
+      }
       return;
     }
 
@@ -1317,6 +1321,10 @@ function initializeColorPicker(preSelected = selectedColor) {
 
     const newDateStr = currentDate.toISOString().split('T')[0];
     openJournal(newDateStr);
+    const habitForm = document.getElementById('habitForm');
+    if (habitForm.style.display !== 'none') {
+      _changeToHabit();
+    }
   }
 
   /*******************************************************


### PR DESCRIPTION
## Summary
- update `changeJournalDay` so the habit tracker stays in sync when using the prev/next arrows

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685c307890ec8328b0e324ec8618e26a