### PR TITLE
Enable push notifications in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ https://ksteele98.github.io/mywebsite/firebase-messaging-sw.js
 ```
 
 When the app receives a push while closed, this service worker's `onBackgroundMessage` callback displays the notification.
+
+On mobile devices install the PWA ("Add to Home Screen") and tap the **Enable Notifications** button once signed in. Notifications will then appear even when the app isn't open.

--- a/firebase-messaging-sw.js
+++ b/firebase-messaging-sw.js
@@ -21,3 +21,21 @@ messaging.onBackgroundMessage(({ data }) => {
   const body  = data?.body  ?? '';
   self.registration.showNotification(title, { body });
 });
+
+// Focus/open the app when the user taps a notification
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true })
+      .then(clientList => {
+        for (const client of clientList) {
+          if (client.url.includes('/mywebsite/') && 'focus' in client) {
+            return client.focus();
+          }
+        }
+        if (clients.openWindow) {
+          return clients.openWindow('/mywebsite/');
+        }
+      })
+  );
+});

--- a/index.html
+++ b/index.html
@@ -896,30 +896,41 @@ async function initFCM() {
   });
   console.log('✅ SW registered');
 
+  async function subscribeForPush() {
+    const messaging = getMessaging(app);
+    const swReg = await navigator.serviceWorker.ready;
+    const fcmToken = await getToken(messaging, {
+      vapidKey: 'BHI71aycFWx3ntjc3nuZvAGDvAakYzBd-0cCRl8YuswkYkX3hQ9j4sysD6XXNBWrPZSsGHB2isMfC6u-3Uounzo',
+      serviceWorkerRegistration: swReg
+    });
+    console.log('✅ FCM token acquired:', fcmToken);
+    const uid = auth.currentUser?.uid;
+    if (uid) await setDoc(doc(db, 'users', uid), { fcmToken }, { merge: true });
+    const subBtn = document.getElementById('subscribeBtn');
+    if (subBtn) {
+      subBtn.disabled = true;
+      subBtn.textContent = 'Notifications On';
+    }
+  }
+
   const subBtn = document.getElementById('subscribeBtn');
   if (!subBtn) return;
   subBtn.addEventListener('click', async () => {
     if (await Notification.requestPermission() !== 'granted') return;
-
-    const messaging = getMessaging(app);                 // modular in main thread
-    const swReg     = await navigator.serviceWorker.ready;
-
     try {
-      const fcmToken = await getToken(messaging, {
-        vapidKey: 'BHI71aycFWx3ntjc3nuZvAGDvAakYzBd-0cCRl8YuswkYkX3hQ9j4sysD6XXNBWrPZSsGHB2isMfC6u-3Uounzo',
-        serviceWorkerRegistration: swReg
-      });
-      console.log('✅ FCM token acquired:', fcmToken);
-      const uid = auth.currentUser?.uid;
-      if (uid) await setDoc(doc(db, 'users', uid), { fcmToken }, { merge: true });
+      await subscribeForPush();
       alert('🎉 Notifications enabled!');
-      subBtn.disabled = true;
-      subBtn.textContent = 'Notifications On';
     } catch (err) {
       console.error('FCM token error', err);
       alert('Could not subscribe for push. Check console.');
     }
   });
+
+  if (Notification.permission === 'granted') {
+    try { await subscribeForPush(); } catch (err) {
+      console.error('FCM auto-subscribe error', err);
+    }
+  }
 
   const messaging = getMessaging(app);
   // Foreground messages use a data-only payload so we manually


### PR DESCRIPTION
## Summary
- open the PWA when tapping a notification
- auto subscribe for FCM token when permission already granted
- document how to enable mobile notifications

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685c36e5c03c832887dfbeafdb7318d5