### PR TITLE
Use FCM for event reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,22 @@ https://ksteele98.github.io/mywebsite/firebase-messaging-sw.js
 When the app receives a push while closed, this service worker's `onBackgroundMessage` callback displays the notification.
 
 On mobile devices install the PWA ("Add to Home Screen") and tap the **Enable Notifications** button once signed in. Notifications will then appear even when the app isn't open.
+
+## Event reminder pushes
+
+Event reminders now use a Cloud Function to deliver data-only FCM payloads. Set `REMINDER_FUNCTION_URL` in `index.html` to your deployed function's HTTPS endpoint. The included `functions/index.js` exports a `sendReminder` function for Firebase Functions:
+
+```javascript
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+admin.initializeApp();
+
+exports.sendReminder = functions.https.onRequest(async (req, res) => {
+  const { token, title, body } = req.body || {};
+  if (!token || !title || !body) return res.status(400).send('Missing fields');
+  await admin.messaging().send({ token, data: { title, body } });
+  res.send('ok');
+});
+```
+
+Deploy this function and set the URL so scheduled reminders trigger background notifications.

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,0 +1,18 @@
+const functions = require('firebase-functions');
+const admin = require('firebase-admin');
+admin.initializeApp();
+
+exports.sendReminder = functions.https.onRequest(async (req, res) => {
+  const { token, title, body } = req.body || {};
+  if (!token || !title || !body) {
+    res.status(400).send('Missing fields');
+    return;
+  }
+  try {
+    await admin.messaging().send({ token, data: { title, body } });
+    res.status(200).send('ok');
+  } catch (err) {
+    console.error('sendReminder error', err);
+    res.status(500).send('error');
+  }
+});

--- a/index.html
+++ b/index.html
@@ -880,6 +880,9 @@ import {
   onMessage
 } from 'https://www.gstatic.com/firebasejs/10.7.2/firebase-messaging.js';
 
+// Endpoint of the Cloud Function that dispatches FCM pushes
+const REMINDER_FUNCTION_URL = 'YOUR_SEND_REMINDER_URL';
+
 async function fcmSupported() {
   try {
     return await messagingIsSupported();
@@ -904,6 +907,8 @@ async function initFCM() {
       serviceWorkerRegistration: swReg
     });
     console.log('✅ FCM token acquired:', fcmToken);
+    userFcmToken = fcmToken;
+    window.userFcmToken = fcmToken;
     const uid = auth.currentUser?.uid;
     if (uid) await setDoc(doc(db, 'users', uid), { fcmToken }, { merge: true });
     const subBtn = document.getElementById('subscribeBtn');
@@ -960,13 +965,14 @@ initFCM();
   let habitTracker = {};
   let globalHabits = [];
   let journalAudios = {};
-  let journalImages = {};
-  let pendingAudioFile = null;
-  let pendingImageFile = null;
-  let mediaRecorder = null;
-  let recordedChunks = [];
-  let reminderTimeouts = {};
-  let taskControlsInitialized = false;
+let journalImages = {};
+let pendingAudioFile = null;
+let pendingImageFile = null;
+let mediaRecorder = null;
+let recordedChunks = [];
+let reminderTimeouts = {};
+let userFcmToken = null;
+let taskControlsInitialized = false;
 
   // ─── Simple desktop time picker using dropdowns ───
   function isMobileDevice() {
@@ -1457,6 +1463,23 @@ function initializeColorPicker(preSelected = selectedColor) {
   /*******************************************************
    10) Events
   *******************************************************/
+  async function sendReminderPush(title, body) {
+    if (!userFcmToken || !REMINDER_FUNCTION_URL) {
+      new Notification(title, { body });
+      return;
+    }
+    try {
+      await fetch(REMINDER_FUNCTION_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: userFcmToken, title, body })
+      });
+    } catch (err) {
+      console.error('push error', err);
+      new Notification(title, { body });
+    }
+  }
+
   function scheduleReminder(ev) {
     if (!ev.reminderDate || !ev.reminderTime) return;
     const reminderMoment = new Date(ev.reminderDate + 'T' + ev.reminderTime);
@@ -1468,7 +1491,7 @@ function initializeColorPicker(preSelected = selectedColor) {
       if (Notification.permission === 'granted') {
         const timeRange = `${formatTime(ev.startTime)} - ${formatTime(ev.endTime)}`;
         const body = `${timeRange}: ${ev.description}`;
-        new Notification('Event Reminder', { body });
+        sendReminderPush('Event Reminder', body);
       }
     }, timeout);
   }


### PR DESCRIPTION
## Summary
- send scheduled event notifications via FCM data payloads
- expose `sendReminder` Firebase Function used by the frontend
- document how to deploy the function and configure the reminder URL

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685c3a5676d08328a4ed8c669158172a