### PR TITLE
Switch event reminders from push notifications to email

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,21 +29,39 @@ When the app receives a push while closed, this service worker's `onBackgroundMe
 
 On mobile devices install the PWA ("Add to Home Screen") and tap the **Enable Notifications** button once signed in. Notifications will then appear even when the app isn't open.
 
-## Event reminder pushes
+## Event reminder emails
 
-Event reminders now use a Cloud Function to deliver data-only FCM payloads. Set `REMINDER_FUNCTION_URL` in `index.html` to your deployed function's HTTPS endpoint. The included `functions/index.js` exports a `sendReminder` function for Firebase Functions:
+Event reminders are sent using a Cloud Function that emails the user via SendGrid. Set `REMINDER_EMAIL_FUNCTION_URL` in `index.html` to your deployed function's HTTPS endpoint. The included `functions/index.js` exports a `sendEmailReminder` function:
 
 ```javascript
 const functions = require('firebase-functions');
-const admin = require('firebase-admin');
-admin.initializeApp();
+const sgMail = require('@sendgrid/mail');
+sgMail.setApiKey(functions.config().sendgrid.key);
 
-exports.sendReminder = functions.https.onRequest(async (req, res) => {
-  const { token, title, body } = req.body || {};
-  if (!token || !title || !body) return res.status(400).send('Missing fields');
-  await admin.messaging().send({ token, data: { title, body } });
-  res.send('ok');
+exports.sendEmailReminder = functions.https.onRequest(async (req, res) => {
+  const { email, name, event_name, event_time } = req.body || {};
+  if (!email || !name || !event_name || !event_time) {
+    return res.status(400).send('Missing fields');
+  }
+  const msg = {
+    to: email,
+    from: 'kyleasteele98@gmail.com', // Must match verified sender identity in SendGrid
+    subject: `Reminder: ${event_name}`,
+    html: `
+      <h3>Hey ${name},</h3>
+      <p>This is your reminder for <strong>${event_name}</strong>.</p>
+      <p>It starts at: <strong>${event_time}</strong></p>
+    `,
+  };
+
+  try {
+    await sgMail.send(msg);
+    res.status(200).send('Email sent successfully!');
+  } catch (error) {
+    console.error('Error sending email:', error);
+    res.status(500).send('Failed to send email.');
+  }
 });
 ```
 
-Deploy this function and set the URL so scheduled reminders trigger background notifications.
+Deploy this function and set the URL so scheduled reminders send an email to the signed-in user.

--- a/index.html
+++ b/index.html
@@ -809,6 +809,8 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
 
 
   let userId = null;  // will store current Google user's uid here
+  let userEmail = null;
+  let userName = null;
   const provider = new GoogleAuthProvider();
 
   // This function triggers the Google popup
@@ -827,6 +829,8 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
   onAuthStateChanged(auth, async (user) => {
     if (user) {
       userId = user.uid;
+      userEmail = user.email;
+      userName = user.displayName || '';
       // Hide sign in button, show logout button
       document.getElementById('authSection').style.display = 'none';
       document.getElementById('logoutSection').style.display = 'block';
@@ -837,6 +841,9 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
       generateCalendar();
       renderTasks();
     } else {
+      userId = null;
+      userEmail = null;
+      userName = null;
       // Show sign in button, hide logout button
       document.getElementById('authSection').style.display = 'block';
       document.getElementById('logoutSection').style.display = 'none';
@@ -880,8 +887,8 @@ import {
   onMessage
 } from 'https://www.gstatic.com/firebasejs/10.7.2/firebase-messaging.js';
 
-// Endpoint of the Cloud Function that dispatches FCM pushes
-const REMINDER_FUNCTION_URL = 'https://us-central1-my-website-5dfa1.cloudfunctions.net/sendReminder';
+// Endpoint of the Cloud Function that sends reminder emails
+const REMINDER_EMAIL_FUNCTION_URL = 'https://us-central1-my-website-5dfa1.cloudfunctions.net/sendEmailReminder';
 
 let userFcmToken = null;
 
@@ -1464,20 +1471,21 @@ function initializeColorPicker(preSelected = selectedColor) {
   /*******************************************************
    10) Events
   *******************************************************/
-  async function sendReminderPush(title, body) {
-    if (!userFcmToken || !REMINDER_FUNCTION_URL) {
-      new Notification(title, { body });
-      return;
-    }
+  async function sendReminderEmail(ev) {
+    if (!userEmail || !REMINDER_EMAIL_FUNCTION_URL) return;
     try {
-      await fetch(REMINDER_FUNCTION_URL, {
+      await fetch(REMINDER_EMAIL_FUNCTION_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: userFcmToken, title, body })
+        body: JSON.stringify({
+          email: userEmail,
+          name: userName || '',
+          event_name: ev.description,
+          event_time: formatTime(ev.startTime)
+        })
       });
     } catch (err) {
-      console.error('push error', err);
-      new Notification(title, { body });
+      console.error('email reminder error', err);
     }
   }
 
@@ -1489,11 +1497,12 @@ function initializeColorPicker(preSelected = selectedColor) {
     const idx = events.indexOf(ev);
     if (reminderTimeouts[idx]) clearTimeout(reminderTimeouts[idx]);
     reminderTimeouts[idx] = setTimeout(() => {
+      const timeRange = `${formatTime(ev.startTime)} - ${formatTime(ev.endTime)}`;
+      const body = `${timeRange}: ${ev.description}`;
       if (Notification.permission === 'granted') {
-        const timeRange = `${formatTime(ev.startTime)} - ${formatTime(ev.endTime)}`;
-        const body = `${timeRange}: ${ev.description}`;
-        sendReminderPush('Event Reminder', body);
+        new Notification('Event Reminder', { body });
       }
+      sendReminderEmail(ev);
     }, timeout);
   }
 


### PR DESCRIPTION
## Summary
- store user email/name on login
- call new SendGrid cloud function from reminders
- document email reminder function in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685c606fd8888328a63c99119bcc8d77