### PR TITLE
Mirror events to Firestore

### DIFF
--- a/index.html
+++ b/index.html
@@ -780,7 +780,15 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
     onAuthStateChanged,
     signOut
   } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-auth.js";
-  import { getFirestore, doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-firestore.js";
+  import {
+    getFirestore,
+    doc,
+    getDoc,
+    setDoc,
+    collection,
+    addDoc,
+    Timestamp
+  } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-firestore.js";
   import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-storage.js";
   // NEW: push-subscription flow -------------------------------
 
@@ -1511,6 +1519,13 @@ function initializeColorPicker(preSelected = selectedColor) {
     reminderTimeouts = {};
     events.forEach(scheduleReminder);
   }
+
+  function getReminderMinutes(ev) {
+    if (!ev.reminderDate || !ev.reminderTime) return null;
+    const start = new Date(`${ev.date}T${ev.startTime}`);
+    const remind = new Date(`${ev.reminderDate}T${ev.reminderTime}`);
+    return Math.round((start - remind) / 60000);
+  }
   function addEvent(date) {
     const eventForm = document.getElementById('eventForm');
     document.getElementById('eventDate').value = date;
@@ -1582,6 +1597,24 @@ function initializeColorPicker(preSelected = selectedColor) {
       // New
       events.push(eventData);
     }
+
+    // -----------------------------------------
+    // NEW: mirror this event into Firestore ➜ “events” collection
+    // -----------------------------------------
+    try {
+      const reminderMinutes = getReminderMinutes(eventData);
+      await addDoc(collection(db, "events"), {
+        title:     eventData.description,
+        startTime: Timestamp.fromDate(new Date(`${eventData.date}T${eventData.startTime}`)),
+        reminderMinutes,
+        email:     userEmail,
+        name:      userName || '',
+        emailSent: false
+      });
+    } catch (err) {
+      console.error("❌ Failed to save event to Firestore:", err);
+    }
+
     saveUserData();
     scheduleAllReminders();
 


### PR DESCRIPTION
## Summary
- extend Firestore imports
- add helper `getReminderMinutes`
- mirror new/updated events to `events` collection when saving

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685c6c32bdc883289c300e41437cf226