### PR TITLE
Add email reminder helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -784,10 +784,7 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
     getFirestore,
     doc,
     getDoc,
-    setDoc,
-    collection,
-    addDoc,
-    Timestamp
+    setDoc
   } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-firestore.js";
   import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-storage.js";
   // NEW: push-subscription flow -------------------------------
@@ -813,6 +810,32 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
   const analytics = getAnalytics(app);
   const auth = getAuth(app);
   const db   = getFirestore(app);
+
+  /*******************************************************
+    🔔  EMAIL-REMINDER HELPER
+  *******************************************************/
+  import { collection, addDoc, Timestamp } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-firestore.js";
+
+  /**
+   * Creates a doc in the `mail` collection that the Firebase
+   * Trigger-Email extension will send at `delivery.startTime`.
+   */
+  async function queueEmailReminder ({ to, subject, html, sendAt }) {
+    if (!to || !sendAt) return;        // nothing to do
+    try {
+      await addDoc(collection(db, "mail"), {
+        to,
+        message: { subject, html },
+        delivery: {
+          startTime: Timestamp.fromDate(sendAt)   // <-- key field!
+        }
+      });
+      console.log("📧 Email reminder queued:", subject, sendAt);
+    } catch (err) {
+      console.error("⚠️  Could not queue email reminder:", err);
+    }
+  }
+
   const storage = getStorage(app);
 
 


### PR DESCRIPTION
## Summary
- adjust Firestore imports
- add a new `queueEmailReminder` helper after initializing the Firestore database

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685c9d9fbfb483288f44abd878296a1c