### PR TITLE
Add email reminder queuing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1621,6 +1621,22 @@ function initializeColorPicker(preSelected = selectedColor) {
       console.error("❌ Failed to save event to Firestore:", err);
     }
 
+    // -----------------------------------------
+    // NEW: send email if the user picked a reminder
+    // -----------------------------------------
+    if (reminderDate && reminderTime && userEmail) {
+      const sendAt = new Date(`${reminderDate}T${reminderTime}`);
+      if (sendAt > new Date()) {        // future-only
+        const niceTime = formatTime(startTime);
+        queueEmailReminder({
+          to:      userEmail,
+          subject: `⏰ Reminder: ${description}`,
+          html:    `<p><strong>${description}</strong> starts at ${niceTime}.</p>`,
+          sendAt
+        });
+      }
+    }
+
     saveUserData();
     scheduleAllReminders();
 


### PR DESCRIPTION
## Summary
- queue reminder email in `saveEvent` when user sets a reminder

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685c9db7143083289b8b903a1e845254