### PR TITLE
Add SendGrid front-end test page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,6 @@ On mobile devices install the PWA ("Add to Home Screen") and tap the **Enable No
 const functions = require('firebase-functions');
 const sgMail = require('@sendgrid/mail');
 
+
+## SendGrid Frontend Test
+The `sendgrid-test.html` file demonstrates using SendGrid's REST API directly from the browser. A placeholder API key `SG.YOUR_REAL_API_KEY_HERE` is provided. **Never commit your real SendGrid credentials.** Replace the placeholder key with your own when testing locally.

--- a/sendgrid-test.html
+++ b/sendgrid-test.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>SendGrid Test</title>
+</head>
+<body>
+
+  <h1>SendGrid Email Test</h1>
+  <button onclick="sendEmail()">Send Email</button>
+
+  <script>
+    const sendEmail = async () => {
+      const response = await fetch("https://api.sendgrid.com/v3/mail/send", {
+        method: "POST",
+        headers: {
+          "Authorization": "Bearer SG.YOUR_REAL_API_KEY_HERE", // ⚠️ Replace this
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          personalizations: [{
+            to: [{ email: "kyleasteele98@gmail.com" }],
+            subject: "Test Email from JS",
+          }],
+          from: { email: "your_verified_sender@example.com" }, // ⚠️ Must match verified sender
+          content: [{ type: "text/html", value: "This is a test email from JavaScript!" }],
+        }),
+      });
+
+      const result = await response.text();
+      console.log("SendGrid response:", result);
+    };
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `sendgrid-test.html` for front-end SendGrid testing
- document usage in `README.md`

## Testing
- `echo 'no tests'`

------
https://chatgpt.com/codex/tasks/task_b_685d9828e57c83289f4e65f99d7ec090