### PR TITLE
Hide SendGrid key in test page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ const sgMail = require('@sendgrid/mail');
 
 
 ## SendGrid Frontend Test
-The `sendgrid-test.html` file demonstrates using SendGrid's REST API directly from the browser. A placeholder API key `SG.YOUR_REAL_API_KEY_HERE` is provided. **Never commit your real SendGrid credentials.** Replace the placeholder key with your own when testing locally.
+The `sendgrid-test.html` page now posts to the `/sendEmail` Cloud Function rather than calling SendGrid directly. This keeps your SendGrid API key on the server. Configure the key with `firebase functions:config:set sendgrid.key=YOUR_KEY` before deploying.

--- a/functions/index.js
+++ b/functions/index.js
@@ -33,6 +33,31 @@ exports.sendEmailReminder = functions.https.onRequest((req, res) => {
     }
   });
 });
+
+exports.sendEmail = functions.https.onRequest((req, res) => {
+  cors(req, res, async () => {
+    const { to, subject, html } = req.body || {};
+
+    if (!to || !subject || !html) {
+      return res.status(400).send('Missing fields');
+    }
+
+    const msg = {
+      to,
+      from: 'kyleasteele98@gmail.com', // 🔁 Must match verified sender identity in SendGrid
+      subject,
+      html,
+    };
+
+    try {
+      await sgMail.send(msg);
+      res.status(200).send('Email sent successfully!');
+    } catch (error) {
+      console.error('Error sending email:', error);
+      res.status(500).send('Failed to send email.');
+    }
+  });
+});
 const admin = require('firebase-admin');
 admin.initializeApp();
 

--- a/sendgrid-test.html
+++ b/sendgrid-test.html
@@ -10,24 +10,20 @@
 
   <script>
     const sendEmail = async () => {
-      const response = await fetch("https://api.sendgrid.com/v3/mail/send", {
+      const response = await fetch("/sendEmail", {
         method: "POST",
         headers: {
-          "Authorization": "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", // ⚠️ Replace this
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          personalizations: [{
-            to: [{ email: "kyleasteele98@gmail.com" }],
-            subject: "Test Email from JS",
-          }],
-          from: { email: "kyleasteele98@gmail.com" }, // ⚠️ Must match verified sender
-          content: [{ type: "text/html", value: "This is a test email from JavaScript!" }],
+          to: "kyleasteele98@gmail.com",
+          subject: "Test Email from JS",
+          html: "This is a test email from JavaScript!",
         }),
       });
 
       const result = await response.text();
-      console.log("SendGrid response:", result);
+      console.log("Server response:", result);
     };
   </script>
 


### PR DESCRIPTION
## Summary
- route SendGrid test page through a cloud function instead of calling the API directly
- expose a new `sendEmail` cloud function
- document the safer approach in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685d9cf7709c83289c633513f96c747d