### PR TITLE
Enable deleting recorded audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -1478,6 +1478,7 @@ function initializeColorPicker(preSelected = selectedColor) {
         audioPlayer.load();
         pendingAudioFile = new File([blob], 'journal.webm', { type: mimeType });
         document.getElementById('recordAudioBtn').textContent = 'Start Recording';
+        document.getElementById('removeAudioBtn').style.display = 'block';
       };
       mediaRecorder.start();
       document.getElementById('recordAudioBtn').textContent = 'Stop Recording';


### PR DESCRIPTION
## Summary
- show the 'remove audio' button when recording stops so users can delete their recording

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*
- `cd functions && npm test` *(fails: missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_6866e0ccc3f0832894bc26e8b9690b98