### PR TITLE
Enable cloud image storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -845,7 +845,7 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
     getDoc,
     setDoc
   } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-firestore.js";
-  import { getStorage, ref, uploadBytes, getDownloadURL } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-storage.js";
+  import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-storage.js";
   // NEW: push-subscription flow -------------------------------
 
   /********************** 
@@ -1387,18 +1387,17 @@ function initializeColorPicker(preSelected = selectedColor) {
       }
     });
 
-    // Load image from IndexedDB
-    getFromDB('images', date).then(blob => {
-      if (blob) {
-        imagePreview.src = URL.createObjectURL(blob);
-        imagePreview.style.display = 'block';
-        removeImageBtn.style.display = 'block';
-      } else {
-        imagePreview.src = '';
-        imagePreview.style.display = 'none';
-        removeImageBtn.style.display = 'none';
-      }
-    });
+    // Load image from Firebase Storage
+    const imageUrl = journalImages[date];
+    if (imageUrl) {
+      imagePreview.src = imageUrl;
+      imagePreview.style.display = 'block';
+      removeImageBtn.style.display = 'block';
+    } else {
+      imagePreview.src = '';
+      imagePreview.style.display = 'none';
+      removeImageBtn.style.display = 'none';
+    }
 
     document.getElementById('prevDayButton').style.display = 'block';
     document.getElementById('nextDayButton').style.display = 'block';
@@ -1570,7 +1569,7 @@ function initializeColorPicker(preSelected = selectedColor) {
     recordBtn.textContent = 'Start Recording';
   }
 
-  function removeImage() {
+  async function removeImage() {
     const preview = document.getElementById('imagePreview');
     const imageInput = document.getElementById('imageFileInput');
     const date = document.getElementById('journalForm').dataset.date;
@@ -1578,7 +1577,13 @@ function initializeColorPicker(preSelected = selectedColor) {
     preview.style.display = 'none';
     imageInput.value = '';
     pendingImageFile = null;
-    deleteFromDB('images', date);
+    try {
+      await deleteObject(ref(storage, `journalImages/${userId}/${date}`));
+    } catch (err) {
+      console.error('Error deleting image:', err);
+    }
+    delete journalImages[date];
+    await saveUserData();
     document.getElementById('removeImageBtn').style.display = 'none';
   }
 
@@ -1839,10 +1844,13 @@ async function saveJournal() {
   }
 
   try {
-    // IMAGE Save to IndexedDB
+    // IMAGE Save to Firebase Storage
     if (pendingImageFile) {
-      await saveToDB('images', date, pendingImageFile);
-      console.log("Image saved locally for date:", date);
+      const imgRef = ref(storage, `journalImages/${userId}/${date}`);
+      await uploadBytes(imgRef, pendingImageFile);
+      const url = await getDownloadURL(imgRef);
+      journalImages[date] = url;
+      console.log("Image uploaded for date:", date);
     }
     // AUDIO Save to IndexedDB
     if (pendingAudioFile) {
@@ -1859,10 +1867,11 @@ async function saveJournal() {
     // Clear pending files
     pendingAudioFile = null;
     pendingImageFile = null;
+    await saveUserData();
     generateCalendar();
     updateDailyEventsList(date);
     closeJournalForm();
-    console.log('✅ Journal saved locally');
+    console.log('✅ Journal saved');
   } catch (err) {
     console.error("Error in saveJournal:", err);
     alert("Error saving journal: " + err.message);


### PR DESCRIPTION
## Summary
- upload journal images to Firebase Storage instead of IndexedDB
- display stored image URLs when opening an entry
- allow removing images from Storage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6869f0f23120832dbcf8994a9fb5e40b