### PR TITLE
Hide notifications button after enabling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1039,6 +1039,7 @@ async function initFCM() {
     if (subBtn) {
       subBtn.disabled = true;
       subBtn.textContent = 'Notifications On';
+      subBtn.style.display = 'none';
     }
   }
 


### PR DESCRIPTION
## Summary
- hide `Enable Notifications` button after subscribing for push notifications

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ad8d57c24832da185034da5bbc2af