### PR TITLE
Remove email and Pushover reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,27 +31,10 @@ On mobile devices install the PWA ("Add to Home Screen") and tap the **Enable No
 
 ## Reminders
 
-When creating an event you can optionally pick a **Reminder Date** and **Reminder Time**. The page will queue an email through the `mail` collection and schedule a local notification. After saving an event you'll see a browser alert confirming the reminder time.
+When creating an event you can optionally pick a **Reminder Date** and **Reminder Time**. The page schedules a local notification and stores the reminder in Firestore. After saving an event you'll see a browser alert confirming the reminder time.
 
 
 ### Firebase Setup
 
-Deploy the Cloud Functions in `functions/` and install the [Trigger Email](https://firebase.google.com/products/extensions/firestore-send-email) extension. The `sendReminders` scheduled function checks the `events` collection every five minutes and sends push notifications (using each user's `fcmToken`) and queues an email in the `mail` collection.
+Deploy the Cloud Functions in `functions/`. The `sendReminders` scheduled function checks the `events` collection every five minutes and sends push notifications using each user's `fcmToken`.
 
-### Pushover Support
-
-You can also receive reminders through the [Pushover](https://pushover.net/) service. Set your app's token using Firebase config:
-
-```bash
-firebase functions:config:set pushover.token="YOUR_APP_TOKEN"
-```
-
-Store each user's Pushover user key under `pushoverKey` in their `users/{uid}` document. When `sendReminders` runs it will send a message via Pushover in addition to FCM/email.
-
-### Pushover Queue
-
-For one-off Pushover messages write documents to a `pushoverQueue` collection
-with the fields `userKey`, `apiToken`, `message`, `sendAt` (a Firestore
-`Timestamp`) and a `fired` boolean. The `pushoverDispatcher` Cloud Function runs
-every minute and sends any entries whose `sendAt` time has passed, then marks
-them as fired.

--- a/index.html
+++ b/index.html
@@ -870,7 +870,10 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
     getFirestore,
     doc,
     getDoc,
-    setDoc
+    setDoc,
+    addDoc,
+    collection,
+    Timestamp
   } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-firestore.js";
   import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-storage.js";
   // NEW: push-subscription flow -------------------------------
@@ -897,37 +900,10 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
   const auth = getAuth(app);
   const db   = getFirestore(app);
 
-  /*******************************************************
-    🔔  EMAIL-REMINDER HELPER
-  *******************************************************/
-  import { collection, addDoc, Timestamp } from "https://www.gstatic.com/firebasejs/10.7.2/firebase-firestore.js";
-
-  /**
-   * Creates a doc in the `mail` collection that the Firebase
-   * Trigger-Email extension will send at `delivery.startTime`.
-   */
-  async function queueEmailReminder ({ to, subject, html, sendAt }) {
-    if (!to || !sendAt) return;        // nothing to do
-    try {
-      await addDoc(collection(db, "mail"), {
-        to: ["kyleblazer13@gmail.com"],
-        message: { subject, html },
-        delivery: {
-          startTime: Timestamp.fromDate(sendAt)   // <-- key field!
-        }
-      });
-      console.log("📧 Email reminder queued:", subject, sendAt);
-    } catch (err) {
-      console.error("⚠️  Could not queue email reminder:", err);
-    }
-  }
-
   const storage = getStorage(app);
 
 
   let userId = null;  // will store current Google user's uid here
-  let userEmail = null;
-  let userName = null;
   const provider = new GoogleAuthProvider();
 
   // This function triggers the Google popup
@@ -946,8 +922,6 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
   onAuthStateChanged(auth, async (user) => {
     if (user) {
       userId = user.uid;
-      userEmail = user.email;
-      userName = user.displayName || '';
       // Hide sign in button, show logout button
       document.getElementById('authSection').style.display = 'none';
       document.getElementById('logoutSection').style.display = 'block';
@@ -960,8 +934,6 @@ box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 90%; max-width: 600px; max-height
       renderTasks();
     } else {
       userId = null;
-      userEmail = null;
-      userName = null;
       // Show sign in button, hide logout button
       document.getElementById('authSection').style.display = 'block';
       document.getElementById('logoutSection').style.display = 'none';
@@ -1835,8 +1807,6 @@ function initializeColorPicker(preSelected = selectedColor) {
         title:     eventData.description,
         startTime: Timestamp.fromDate(new Date(`${eventData.date}T${eventData.startTime}`)),
         reminderMinutes,
-        email:     userEmail,
-        name:      userName || '',
         uid:       userId,
         emailSent: false
       });
@@ -1844,22 +1814,7 @@ function initializeColorPicker(preSelected = selectedColor) {
       console.error("❌ Failed to save event to Firestore:", err);
     }
 
-    // -----------------------------------------
-    // NEW: send email if the user picked a reminder
-    // -----------------------------------------
-    if (reminderDate && reminderTime && userEmail) {
-      const sendAt = new Date(`${reminderDate}T${reminderTime}`);
-      if (sendAt > new Date()) {        // future-only
-        const niceTime = formatTime(startTime);
-        queueEmailReminder({
-          to:      userEmail,
-          subject: `⏰ Reminder: ${description}`,
-          html:    `<p><strong>${description}</strong> starts at ${niceTime}.</p>`,
-          sendAt
-        });
-        alert(`Reminder scheduled for ${sendAt.toLocaleString()}`);
-      }
-    }
+
 
     saveUserData();
     scheduleAllReminders();


### PR DESCRIPTION
## Summary
- stop queueing email and Pushover messages
- simplify reminder Cloud Function to send only FCM notifications
- update imports and event creation in `index.html`
- document new reminder flow in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ae00347dc832d8300b0b86f49382e