### PR TITLE
Fix missed reminders popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -2535,7 +2535,6 @@ Object.assign(window, {
 generateCalendar();   // render current month on first load
 scheduleAllReminders();
 scheduleAllTaskReminders();
-showMissedReminders();
 
 document.getElementById('pendingBtn').addEventListener('click', showPendingNotifications);
 


### PR DESCRIPTION
## Summary
- fix missed reminders popup by removing premature call

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `functions` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ae1ed9294832d941b06c061338a92