### PR TITLE
Enable decimal habit counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -2757,13 +2757,14 @@ function renderHabits(date) {
         const count = document.createElement('input');
         count.type = 'number';
         count.min = '0';
+        count.step = 'any';
         count.style.width = '60px';
         count.style.marginRight = '10px';
         count.value = habitTracker[date]?.[habit.id]?.count || 0;
         count.onchange = () => {
           habitTracker[date] = habitTracker[date] || {};
           habitTracker[date][habit.id] = habitTracker[date][habit.id] || {};
-          habitTracker[date][habit.id].count = parseInt(count.value) || 0;
+          habitTracker[date][habit.id].count = parseFloat(count.value) || 0;
         };
         label.appendChild(count);
       }


### PR DESCRIPTION
## Summary
- allow decimal counts for habits in Habit Tracker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873d20aca74832da94a8cc4efda4914