### PR TITLE
Store journal image URL in Firebase Storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1980,7 +1980,19 @@ async function saveJournal() {
   try {
     // IMAGE Save to Firebase Storage
     if (pendingImageFile) {
-      const imgRef = ref(storage, `journalImages/${userId}/${date}`);
+      const imgRef = ref(storage, `journalImages/${userId}/${date}/${pendingImageFile.name}`);
+
+      // 1️⃣  push the bytes
+      await uploadBytes(imgRef, pendingImageFile);
+
+      // 2️⃣  grab a public (authenticated) download URL
+      const url = await getDownloadURL(imgRef);
+
+      // 3️⃣  remember it in our per-date map
+      journalImages[date] = url;
+
+      // 4️⃣  clear the local flag
+      pendingImageFile = null;
 
       console.log("Image uploaded for date:", date);
     }


### PR DESCRIPTION
## Summary
- upload journal images to Firebase Storage
- store the resulting download URL in the per-date `journalImages` map

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687bcab5086c832d9b101d7aff0bf33b