### PR TITLE
Show cloud image on journal open

### DIFF
--- a/index.html
+++ b/index.html
@@ -1420,13 +1420,20 @@ function initializeColorPicker(preSelected = selectedColor) {
       }
     });
 
+    // Show cloud-hosted image immediately if available
+    if (journalImages[date]) {
+      imagePreview.src = journalImages[date];
+      imagePreview.style.display = 'block';
+      removeImageBtn.style.display = 'block';
+    }
+
     // Load image from IndexedDB
     getFromDB('images', date).then(blob => {
       if (blob) {
         imagePreview.src = URL.createObjectURL(blob);
         imagePreview.style.display = 'block';
         removeImageBtn.style.display = 'block';
-      } else {
+      } else if (!journalImages[date]) {
         imagePreview.src = '';
         imagePreview.style.display = 'none';
         removeImageBtn.style.display = 'none';


### PR DESCRIPTION
## Summary
- display remote journal image if available before checking local cache

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bcac2356c832da6a9f3795fc2d889