### PR TITLE
Adjust journal and navigation arrows on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,10 +587,22 @@
       .event {
         margin-bottom: 1px;
       }
-      .event-form, .journal-form {
+      .event-form {
         width: 95%;
         padding: 15px;
       }
+      .journal-form {
+        width: 80%;
+        padding: 15px;
+      }
+      .day-nav-button {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        bottom: auto;
+      }
+      #prevDayButton { left: -50px; }
+      #nextDayButton { right: -50px; }
       .time-inputs div {
         flex: 100%;
       }
@@ -784,12 +796,11 @@
 
   <button onclick="saveJournal()">Save</button>
   <button onclick="closeJournalForm()">Cancel</button>
+
+  <!-- Prev / Next Journal Buttons -->
+  <button id="prevDayButton" class="nav-button day-nav-button" onclick="changeJournalDay(-1)">&lt;</button>
+  <button id="nextDayButton" class="nav-button day-nav-button" onclick="changeJournalDay(1)">&gt;</button>
 </div>
-
-<!-- Prev / Next Journal Buttons -->
-<button id="prevDayButton" class="nav-button day-nav-button" onclick="changeJournalDay(-1)">&lt;</button>
-
-<button id="nextDayButton" class="nav-button day-nav-button" onclick="changeJournalDay(1)">&gt;</button>
 
 <!-- Habit Form -->
 <div class="habit-form" id="habitForm" style="display: none;" data-date="">


### PR DESCRIPTION
## Summary
- Shrink journal modal on small screens and reposition navigation arrows to flank it.
- Embed prev/next journal buttons inside journal container for better mobile UX.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891204ac7cc832d8612d8d9412515a3