### PR TITLE
Position journal navigation arrows outside

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,13 +80,14 @@
       height: 40px;
       min-width: 40px;
       border-radius: 50%;
-      position: fixed;
-      bottom: 20px;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
       z-index: 1001;
       display: none;
     }
-    #prevDayButton { left: 10px; }
-    #nextDayButton { right: 10px; }
+    #prevDayButton { left: -45px; }
+    #nextDayButton { right: -45px; }
     .current-month {
       font-size: 20px;
       font-weight: bold;
@@ -239,8 +240,7 @@
       border-radius: 8px;
       box-shadow: 0 2px 10px rgba(0,0,0,0.1);
       display: none;
-      width: 90%;
-      max-width: 600px;
+      width: calc(100% - 90px);
       max-height: 90vh;
       overflow-y: auto;
       z-index: 1000;
@@ -592,17 +592,9 @@
         padding: 15px;
       }
       .journal-form {
-        width: 80%;
+        width: calc(100% - 90px);
         padding: 15px;
       }
-      .day-nav-button {
-        position: absolute;
-        top: 50%;
-        transform: translateY(-50%);
-        bottom: auto;
-      }
-      #prevDayButton { left: -50px; }
-      #nextDayButton { right: -50px; }
       .time-inputs div {
         flex: 100%;
       }


### PR DESCRIPTION
## Summary
- move journal day navigation arrows outside the journal container and center vertically
- slightly reduce journal width so arrows remain visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689122bb3694832dbfc0edbc50a0381f