### PR TITLE
Add light blue borders and prevent horizontal scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,10 @@
       font-family: Arial, sans-serif;
       margin: 0;
       padding: 20px;
+      border: 2px solid lightblue;
+      box-sizing: border-box;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
     .calendar-container {
       max-width: 1200px;
@@ -239,7 +243,8 @@
       padding: 20px;
       border-radius: 8px;
       box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-      border: none;
+      border: 2px solid lightblue;
+      box-sizing: border-box;
       display: none;
       width: calc(100% - 90px);
       max-height: 90vh;
@@ -247,7 +252,7 @@
       z-index: 1000;
     }
     .journal-form.today {
-      border: 2px solid blue;
+      border-color: lightblue;
     }
     .close-btn {
       position: absolute;
@@ -265,7 +270,8 @@
       padding: 10px;
       resize: vertical;
       box-sizing: border-box;
-      border: none;
+      border: 1px solid lightblue;
+      overflow-x: hidden;
     }
     .other-month {
       background-color: #f5f5f5;


### PR DESCRIPTION
## Summary
- Prevent horizontal scrolling and add a light blue frame to the page
- Highlight journal entries with a light blue border

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68912de6fd7c832da8a32d34bcf04dcb