### PR TITLE
Remove legacy completed tasks from task lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -1236,19 +1236,17 @@ initFCM();
         userLastOpenTime = data.lastOpenTime || parseInt(localStorage.getItem('lastOpenTime') || '0', 10);
         document.getElementById('goalsText').value = data.userGoals || '';
 
-        renderTaskListButtons();
-        initializeTaskControls();
-        scheduleAllTaskReminders();
       } else {
         console.log("No existing Firestore doc for this user; starting fresh.");
         taskLists = { personal: [], work: [] };
         completedTasks = {};
         userLastOpenTime = parseInt(localStorage.getItem('lastOpenTime') || '0', 10);
-
-        renderTaskListButtons();
-        initializeTaskControls();
-        scheduleAllTaskReminders();
       }
+
+      await migrateAndCleanCompletedTasks();
+      renderTaskListButtons();
+      initializeTaskControls();
+      scheduleAllTaskReminders();
     } catch (err) {
       console.error("Error loading user data:", err);
     }
@@ -1329,11 +1327,11 @@ initFCM();
       taskLists = newActiveTaskLists;
 
       console.log(`Cleanup complete. Migrated ${tasksMigrated} tasks.`);
-      alert(`Cleanup complete! Migrated ${tasksMigrated} previously completed tasks to their correct dates.`);
+      if (tasksMigrated > 0) {
+          await saveUserData();
+          alert(`Cleanup complete! Migrated ${tasksMigrated} previously completed tasks to their correct dates.`);
+      }
 
-      // Finally, save all the changes back to Firestore.
-      await saveUserData();
-      
       // Refresh the UI to show the clean lists.
       renderTasks();
   }


### PR DESCRIPTION
## Summary
- Clean up old completed tasks when loading user data
- Only save and alert when tasks are migrated during cleanup

## Testing
- `npm test --prefix functions` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689626e704a4832d85f73e6404548f49