### PR TITLE
Support comma-separated task input

### DIFF
--- a/index.html
+++ b/index.html
@@ -2228,21 +2228,24 @@ initFCM();
     const severity = parseInt(severitySelect.value, 10) || 0;
     const dateKey = document.getElementById('journalForm').dataset.date || formatLocalDate(new Date());
     if (!taskLists[currentTaskList]) taskLists[currentTaskList] = [];
-    
-    const newTaskId = Date.now();
-    const newTask = {
-      text: text,
-      id: newTaskId,
-      repeat: "none",
-      startDate: dateKey,
-      completed: false,
-      completions: {},
-      subtasks: [],
-      collapsed: false,
-      severity
-    };
 
-    taskLists[currentTaskList].push(newTask);
+    const tasks = text.split(',').map(t => t.trim()).filter(t => t);
+    const baseId = Date.now();
+    tasks.forEach((t, idx) => {
+      const newTask = {
+        text: t,
+        id: baseId + idx,
+        repeat: "none",
+        startDate: dateKey,
+        completed: false,
+        completions: {},
+        subtasks: [],
+        collapsed: false,
+        severity
+      };
+      taskLists[currentTaskList].push(newTask);
+    });
+
     taskInput.value = "";
     severitySelect.value = '0';
     saveUserData();


### PR DESCRIPTION
## Summary
- Split comma-separated entries into individual tasks when adding new tasks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68965b185558832d8c6c31c261b9691b