### PR TITLE
feat: show tasks inside journal

### DIFF
--- a/index.html
+++ b/index.html
@@ -387,30 +387,11 @@
       color: #888;
     }
     .task-container {
-      display: none;
-      position: fixed;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      z-index: 1200;
+      margin-top: 20px;
       background: #fff;
       border: 1px solid #ddd;
       border-radius: 4px;
       padding: 20px;
-      width: 90%;
-      max-width: 400px;
-      max-height: 80%;
-      overflow-y: auto;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-    }
-    .close-task-btn {
-      position: absolute;
-      top: 10px;
-      right: 10px;
-      background: none;
-      border: none;
-      font-size: 24px;
-      cursor: pointer;
     }
     .task-toggle {
       display: flex;
@@ -938,43 +919,39 @@
     <img id="imagePreview" style="display:none; width:100%; margin:10px 0;" />
     <button id="removeImageBtn" class="remove-btn" onclick="removeImage()" style="display:none;">&#215;</button>
   </div>
-  
+  <div class="task-container" id="taskContainer">
+    <div class="tasks-header">
+      <h3>Tasks</h3>
+      <div class="task-buttons">
+        <button id="toggleCompletedBtn" class="new-list-btn" onclick="toggleCompletedView()">Show Completed</button>
+        <button class="new-list-btn" onclick="createNewList()">+ New List</button>
+        <button class="delete-list-btn" onclick="deleteCurrentList()">Delete List</button>
+        <button class="clear-tasks-btn" onclick="clearAllTasks()">Clear All Tasks</button>
+      </div>
+    </div>
+    <div class="task-toggle">
+      <button onclick="switchTaskList('personal')" id="personalTasksBtn" class="active">Personal Tasks</button>
+      <button onclick="switchTaskList('work')" id="workTasksBtn">Work Tasks</button>
+    </div>
+    <label style="display: block; margin: 8px 0; font-size: 14px;">
+      Severity:
+      <select id="taskSeverity" class="task-severity-select">
+        <option value="0" selected></option>
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+        <option value="5">5</option>
+      </select>
+    </label>
 
+    <input type="text" id="taskInput" class="task-input" placeholder="Add a new task">
+    <button class="add-task-btn" onclick="addTask()">Add Task</button>
+    <ul class="task-list" id="taskList"></ul>
+  </div>
 
   <button onclick="saveJournal()">Save</button>
   <button onclick="closeJournalForm()">Cancel</button>
-</div>
-
-<div class="task-container" id="taskContainer">
-  <button class="close-task-btn" onclick="closeTaskPopup()">&times;</button>
-  <div class="tasks-header">
-    <h3>Tasks</h3>
-    <div class="task-buttons">
-      <button id="toggleCompletedBtn" class="new-list-btn" onclick="toggleCompletedView()">Show Completed</button>
-      <button class="new-list-btn" onclick="createNewList()">+ New List</button>
-      <button class="delete-list-btn" onclick="deleteCurrentList()">Delete List</button>
-      <button class="clear-tasks-btn" onclick="clearAllTasks()">Clear All Tasks</button>
-    </div>
-  </div>
-  <div class="task-toggle">
-    <button onclick="switchTaskList('personal')" id="personalTasksBtn" class="active">Personal Tasks</button>
-    <button onclick="switchTaskList('work')" id="workTasksBtn">Work Tasks</button>
-  </div>
-  <label style="display: block; margin: 8px 0; font-size: 14px;">
-    Severity:
-    <select id="taskSeverity" class="task-severity-select">
-      <option value="0" selected></option>
-      <option value="1">1</option>
-      <option value="2">2</option>
-      <option value="3">3</option>
-      <option value="4">4</option>
-      <option value="5">5</option>
-    </select>
-  </label>
-
-  <input type="text" id="taskInput" class="task-input" placeholder="Add a new task">
-  <button class="add-task-btn" onclick="addTask()">Add Task</button>
-  <ul class="task-list" id="taskList"></ul>
 </div>
 
 <button id="prevDayButton" class="nav-button day-nav-button" onclick="changeJournalDay(-1)">&lt;</button>
@@ -2651,16 +2628,6 @@ initFCM();
     document.getElementById("taskReminderForm").style.display = "none";
   }
 
-  function showTaskPopup() {
-    document.getElementById('taskContainer').style.display = 'block';
-  }
-
-  function closeTaskPopup() {
-    document.getElementById('taskContainer').style.display = 'none';
-  }
-
-  window.showTaskPopup = showTaskPopup;
-  window.closeTaskPopup = closeTaskPopup;
   window._openTaskEditor = openTaskEditor;
   window._saveTaskDetails = saveTaskDetails;
   window._closeTaskReminderForm = closeTaskReminderForm;
@@ -2678,18 +2645,6 @@ initFCM();
     toggleTask, deleteTask, switchTaskList, createNewList, deleteCurrentList,
     toggleCompletedView, showPendingNotifications, closeMissedRemindersPopup, closeReminderPopup,
     closePendingRemindersPopup, toggleReminderView
-  });
-
-  document.addEventListener('keydown', (e) => {
-    if ((e.key === 'i' || e.key === 'I') && e.target.tagName !== 'INPUT' && e.target.tagName !== 'TEXTAREA') {
-      e.preventDefault();
-      const container = document.getElementById('taskContainer');
-      if (container.style.display === 'block') {
-        closeTaskPopup();
-      } else {
-        showTaskPopup();
-      }
-    }
   });
 
   initializeTaskControls();


### PR DESCRIPTION
## Summary
- Embed task list directly inside the journal form for easier daily tracking
- Adjust task container styling to fit inline with journal layout
- Remove popup toggle logic and keyboard shortcut since tasks are always visible

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899f2538a30832d8924acb3999fb256