### PR TITLE
Ensure task editor overlays journal

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,8 @@
       display: none;
       width: 90%;
       max-width: 300px;
-      z-index: 1000;
+      /* Ensure the task editor overlays the journal modal */
+      z-index: 1100;
       max-height: 90vh;
       overflow-y: auto;
     }


### PR DESCRIPTION
## Summary
- Raise `task-reminder-form` z-index so editing tasks sits above the journal modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f5e95e74832d83d4b67f6003ee7f