### PR TITLE
Keep journal open when tasks updated

### DIFF
--- a/index.html
+++ b/index.html
@@ -2145,7 +2145,7 @@ initFCM();
 
   /******************************************************* 11) Journal
   *******************************************************/
-  async function saveJournal() {
+  async function saveJournal(closeAfterSave = true) {
       const date = document.getElementById('journalForm').dataset.date;
       const text = document.getElementById('journalText').value.trim();
       if (!userId) {
@@ -2171,7 +2171,7 @@ initFCM();
           await saveUserData();
           generateCalendar();
           updateDailyEventsList(date);
-          closeJournalForm();
+          if (closeAfterSave) closeJournalForm();
           console.log('✅ Journal saved with media synced');
       } catch (err) {
           console.error("Error in saveJournal:", err);
@@ -2372,7 +2372,7 @@ initFCM();
               if (task.completed && task.repeat && task.repeat !== 'none') {
                   await createNextRecurrence(task, currentTaskList);
               }
-              await saveJournal();
+              await saveJournal(false);
               renderTasks();
           };
 
@@ -2577,7 +2577,7 @@ initFCM();
         delete task.repeatDay;
       }
 
-      await saveJournal();
+      await saveJournal(false);
       closeTaskReminderForm();
       renderTasks();
   }


### PR DESCRIPTION
## Summary
- Allow `saveJournal` to optionally keep the journal modal open after saving
- Prevent task completion and edits from closing the journal by saving without closing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f6ca2cdc832d844c9779ccffbf47