### PR TITLE
Remove Clear All Tasks functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,16 +473,6 @@
       min-width: auto;
       flex: 0;
     }
-    .clear-tasks-btn {
-      background: #ffc107;
-      color: #212529;
-      border: none;
-      padding: 8px 16px;
-      border-radius: 4px;
-      cursor: pointer;
-      min-width: auto;
-      flex: 0;
-    }
     .tasks-header {
       display: flex;
       justify-content: space-between;
@@ -945,7 +935,6 @@
         <button id="toggleCompletedBtn" class="new-list-btn" onclick="toggleCompletedView()">Show Completed</button>
         <button class="new-list-btn" onclick="createNewList()">+ New List</button>
         <button class="delete-list-btn" onclick="deleteCurrentList()">Delete List</button>
-        <button class="clear-tasks-btn" onclick="clearAllTasks()">Clear All Tasks</button>
       </div>
     </div>
     <div class="task-toggle">
@@ -1438,37 +1427,6 @@ initFCM();
   }
   // Make the cleanup function accessible from the browser console
   window.migrateAndCleanCompletedTasks = migrateAndCleanCompletedTasks;
-
-
- /*******************************************************
-   Clear all incomplete tasks
-  *******************************************************/
-  async function clearAllTasks() {
-      if (!userId) {
-          console.error("You must be logged in to clear tasks.");
-          alert("You must be logged in to clear tasks.");
-          return;
-      }
-
-      if (!confirm("Clear all incomplete tasks?")) return;
-
-      console.log("Clearing all incomplete tasks...");
-
-      // Remove all tasks from each list
-      for (const listName in taskLists) {
-          taskLists[listName] = [];
-      }
-
-      // Clear any existing reminder timers
-      Object.values(taskReminderTimeouts).forEach(clearTimeout);
-      taskReminderTimeouts = {};
-
-      await saveUserData();
-      renderTasks();
-
-      alert("All incomplete tasks have been cleared.");
-  }
-  window.clearAllTasks = clearAllTasks;
 
 
   /******************************************************* 6) Color Picker
@@ -2245,7 +2203,6 @@ initFCM();
       document.getElementById('toggleCompletedBtn')?.addEventListener('click', toggleCompletedView);
       document.querySelector('.new-list-btn[onclick="createNewList()"]')?.addEventListener('click', createNewList);
       document.querySelector('.delete-list-btn')?.addEventListener('click', deleteCurrentList);
-      document.querySelector('.clear-tasks-btn')?.addEventListener('click', clearAllTasks);
       document.querySelector('.add-task-btn')?.addEventListener('click', addTask);
       updateActiveTaskListButton();
       renderTasks();


### PR DESCRIPTION
## Summary
- remove "Clear All Tasks" button from tasks section
- delete associated event listener and clearAllTasks function
- drop unused styles for .clear-tasks-btn

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a19b300b8832dadd14672a5e5a031