### PR TITLE
Hide completed repeating tasks for the day

### DIFF
--- a/index.html
+++ b/index.html
@@ -2394,7 +2394,11 @@ initFCM();
 
       const dateKey = document.getElementById('journalForm').dataset.date;
       const allTasks = taskLists[currentTaskList] || [];
-      const currentTasks = allTasks.filter(task => occursToday(task, dateKey));
+      // Hide repeating tasks already completed for this day
+      const currentTasks = allTasks.filter(task =>
+        occursToday(task, dateKey) &&
+        !(task.repeat !== "none" && isTaskCompletedForDate(task, dateKey))
+      );
 
       currentTasks.sort((a, b) => {
         const aCompleted = isTaskCompletedForDate(a, dateKey) ? 1 : 0;


### PR DESCRIPTION
## Summary
- Hide repeating tasks from the active list after marking them complete for the day

## Testing
- `npm test` (fails: no package.json)
- `cd functions && npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689c9f7b1ff4832dae2a1d40dca6ed4a