### PR TITLE
Start repeating tasks from current date

### DIFF
--- a/index.html
+++ b/index.html
@@ -2603,7 +2603,12 @@ initFCM();
       task.severity = parseInt(document.getElementById('taskReminderSeverity').value, 10) || 0;
       task.reminderDate = document.getElementById('taskReminderDate').value;
       task.reminderTime = document.getElementById('taskReminderTime').value;
-      task.repeat = document.getElementById('taskRepeat').value;
+      const newRepeat = document.getElementById('taskRepeat').value;
+      const prevRepeat = task.repeat || 'none';
+      task.repeat = newRepeat;
+      if (prevRepeat === 'none' && newRepeat !== 'none') {
+        task.startDate = new Date().toISOString().split('T')[0];
+      }
 
       if (task.repeat === 'weekly') {
         const selectedDayRadio = document.querySelector('input[name="repeatDay"]:checked');


### PR DESCRIPTION
## Summary
- Update task editor save logic to reset startDate when enabling repeat

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/mywebsite/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689c9fedafa0832daa87ce774201d7d7