### PR TITLE
Hide completed repeating tasks for the day

### DIFF
--- a/index.html
+++ b/index.html
@@ -2394,10 +2394,11 @@ initFCM();
 
       const dateKey = document.getElementById('journalForm').dataset.date;
       const allTasks = taskLists[currentTaskList] || [];
-      // Hide repeating tasks already completed for this day
+      // Hide tasks already completed for this day so repeating tasks
+      // disappear only on the days they are checked off
       const currentTasks = allTasks.filter(task =>
         occursToday(task, dateKey) &&
-        !(task.repeat !== "none" && isTaskCompletedForDate(task, dateKey))
+        !isTaskCompletedForDate(task, dateKey)
       );
 
       currentTasks.sort((a, b) => {


### PR DESCRIPTION
## Summary
- ensure completed tasks are hidden for the selected day so repeating tasks stay for future dates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ca228c628832d9563974ef157947a