### PR TITLE
Reposition task action icons to right of task name

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
       flex-direction: column;
       align-items: center;
       gap: 5px;
-      margin-right: 5px;
+      margin-left: 5px;
     }
 
     .edit-task-btn {
@@ -2473,8 +2473,8 @@ initFCM();
 
         taskContent.appendChild(taskRow);
 
-        taskItem.appendChild(controls);
         taskItem.appendChild(taskContent);
+        taskItem.appendChild(controls);
 
         taskListEl.appendChild(taskItem);
       });


### PR DESCRIPTION
## Summary
- Display task edit (ℹ️) and delete (×) buttons on the right side of each task
- Adjust layout spacing for task controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cafcbdebc832d8acb7e33aab34aa2