### PR TITLE
Align task control icons to right

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
       flex-direction: column;
       align-items: center;
       gap: 5px;
-      margin-left: 5px;
+      margin-left: auto;
     }
 
     .edit-task-btn {


### PR DESCRIPTION
## Summary
- Ensure task info (ℹ️) and delete (×) buttons align to the far right of each task item by giving their container auto left margin

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cb17eefd4832db04324b582ccc4ec