### PR TITLE
Ensure unfinished one-time tasks persist until completion

### DIFF
--- a/index.html
+++ b/index.html
@@ -2337,7 +2337,13 @@ initFCM();
 
         switch (task.repeat) {
           case "none":
-            return dateKey === task.startDate;
+            // For one-time tasks, keep them visible on all days after their
+            // start date until they are completed. Previously, non-repeating
+            // tasks would only appear on their start date, making it easy to
+            // lose track of unfinished items. By always returning true here,
+            // the surrounding filters will continue to show the task on future
+            // days until `task.completed` becomes true.
+            return true;
           case "daily":
             return true;
           case "weekdays":


### PR DESCRIPTION
## Summary
- Show non-repeating tasks every day after their start date until they're completed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dd173f748832d88c4c10667f92d1a